### PR TITLE
Center CTA button and update text

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,9 @@ import { Cta } from "@/devlink/Cta"; // Import the Navbar component
 
 export default function Home() {
   return (
-    <Cta></Cta>
+    <div className="flex items-center justify-center min-h-screen">
+      <Cta />
+    </div>
   );
 }
 

--- a/src/devlink/Cta.js
+++ b/src/devlink/Cta.js
@@ -15,7 +15,7 @@ export function Cta({ as: _Component = _Builtin.Link }) {
       }}
     >
       <_Builtin.Block className={_utils.cx(_styles, "text-block")} tag="div">
-        {"This is CTA"}
+        {"Connect wallet"}
       </_Builtin.Block>
     </_Component>
   );

--- a/src/devlink/Cta.module.css
+++ b/src/devlink/Cta.module.css
@@ -2,6 +2,9 @@
   padding: 10px 20px;
   background-color: hsla(12, 100.00%, 50.00%, 1.00);
   text-decoration: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .text-block {


### PR DESCRIPTION
## Summary
- center Cta component on the page with flex container
- update Cta button styling for centered alignment
- change CTA text to "Connect wallet"

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa04a092408333aab494f90cbd7d65